### PR TITLE
Properly return error on start

### DIFF
--- a/metrics/cmd/heapster-apiserver/app/server.go
+++ b/metrics/cmd/heapster-apiserver/app/server.go
@@ -37,8 +37,7 @@ type HeapsterAPIServer struct {
 
 // Run runs the specified APIServer. This should never exit.
 func (h *HeapsterAPIServer) RunServer() error {
-	h.PrepareRun().Run(wait.NeverStop)
-	return nil
+	return h.PrepareRun().Run(wait.NeverStop)
 }
 
 func NewHeapsterApiServer(s *options.HeapsterRunOptions, metricSink *metricsink.MetricSink,


### PR DESCRIPTION
The server does not return errors correctly on startup.