### PR TITLE
Reach nodes on their IPv4 InternalIP address

### DIFF
--- a/metrics/sources/summary/summary.go
+++ b/metrics/sources/summary/summary.go
@@ -16,6 +16,7 @@ package summary
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"time"
 
@@ -399,8 +400,11 @@ func (this *summaryProvider) getNodeInfo(node *corev1.Node) (NodeInfo, error) {
 		if addr.Type == corev1.NodeHostName && addr.Address != "" {
 			info.HostName = addr.Address
 		}
+
 		if addr.Type == corev1.NodeInternalIP && addr.Address != "" {
-			info.IP = addr.Address
+			if net.ParseIP(addr.Address).To4() != nil {
+				info.IP = addr.Address
+			}
 		}
 	}
 


### PR DESCRIPTION
Closes-issue: #56

Disclaimer:
This patch is bad because the metric server will not work
with an IPv6 Kubernetes cluster. However it is consistent
with the code style used in other places in the code, look
at :
metrics/sources/kubelet/kubelet.go:306