### PR TITLE
Add missing nodes/stats resource to the system:metrics-server ClusterRole

### DIFF
--- a/deploy/1.8+/resource-reader.yaml
+++ b/deploy/1.8+/resource-reader.yaml
@@ -8,6 +8,7 @@ rules:
   resources:
   - pods
   - nodes
+  - nodes/stats
   - namespaces
   verbs:
   - get


### PR DESCRIPTION
The following errors were showing up in the `metrics-server` pods:

```
E0514 09:03:05.004174       1 summary.go:97] error while getting metrics summary from Kubelet node-01 (172.18.8.101:10250): request failed - "403 Forbidden", response: "Forbidden (user=system:serviceaccount:kube-system:metrics-server, verb=get, resource=nodes, subresource=stats)"
```

This PR adds the necessary `nodes/stats` resource to the existing `system:metrics-server` role.