### PR TITLE
Format yaml files correctly starting with ---

### DIFF
--- a/deploy/1.7/auth-delegator.yaml
+++ b/deploy/1.7/auth-delegator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:

--- a/deploy/1.7/auth-reader.yaml
+++ b/deploy/1.7/auth-reader.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:

--- a/deploy/1.7/metrics-apiservice.yaml
+++ b/deploy/1.7/metrics-apiservice.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:

--- a/deploy/1.7/metrics-server-deployment.yaml
+++ b/deploy/1.7/metrics-server-deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deploy/1.7/metrics-server-service.yaml
+++ b/deploy/1.7/metrics-server-service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/1.8+/auth-delegator.yaml
+++ b/deploy/1.8+/auth-delegator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:

--- a/deploy/1.8+/auth-reader.yaml
+++ b/deploy/1.8+/auth-reader.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:

--- a/deploy/1.8+/metrics-apiservice.yaml
+++ b/deploy/1.8+/metrics-apiservice.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:

--- a/deploy/1.8+/metrics-server-deployment.yaml
+++ b/deploy/1.8+/metrics-server-deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deploy/1.8+/metrics-server-service.yaml
+++ b/deploy/1.8+/metrics-server-service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/1.8+/resource-reader.yaml
+++ b/deploy/1.8+/resource-reader.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
This is very important for people that want to integrate
these files in scripts and playbooks that call:

    cat *.yaml | kubectl apply -f -

The current syntax is robust against `kubectl apply -f .`
but a lot of scripts out there use the former solution
because for example in the folder they have also other files
that are not yaml.