### PR TITLE
fix halfwayToScrapeTimeout

### DIFF
--- a/pkg/metrics/util.go
+++ b/pkg/metrics/util.go
@@ -31,8 +31,8 @@ func BucketsForScrapeDuration(scrapeTimeout time.Duration) []float64 {
 	maxBucket := buckets[len(buckets)-1]
 	timeoutSeconds := float64(scrapeTimeout) / float64(time.Second)
 	if timeoutSeconds > maxBucket {
-		// [defaults, (scrapeTimeout + (scrapeTimeout - maxBucket)/ 2), scrapeTimeout, scrapeTimeout*1.5, scrapeTimeout*2]
-		halfwayToScrapeTimeout := timeoutSeconds + (timeoutSeconds-maxBucket)/2
+		// [defaults, (maxBucket + (scrapeTimeout - maxBucket)/ 2), scrapeTimeout, scrapeTimeout*1.5, scrapeTimeout*2]
+		halfwayToScrapeTimeout := maxBucket + (timeoutSeconds-maxBucket)/2
 		buckets = append(buckets, halfwayToScrapeTimeout, timeoutSeconds, timeoutSeconds*1.5, timeoutSeconds*2)
 	} else if timeoutSeconds < maxBucket {
 		var i int


### PR DESCRIPTION
fix halfwayToScrapeTimeout: histogram buckets must be in increasing order
```
I0817 03:18:16.093249       1 serving.go:273] Generated self-signed cert (apiserver.local.config/certificates/apiserver.crt, apiserver.local.config/certificates/apiserver.key)
panic: histogram buckets must be in increasing order: 85.000000 >= 60.000000
```