### PR TITLE
Fixed missing flags for starting metrics-server issue #105

### DIFF
--- a/deploy/1.8+/metrics-server-deployment.yaml
+++ b/deploy/1.8+/metrics-server-deployment.yaml
@@ -31,6 +31,9 @@ spec:
       - name: metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.2.1
         imagePullPolicy: Always
+        command:
+          - /metrics-server
+          - --source=kubernetes:https://kubernetes.default
         volumeMounts:
         - name: tmp-dir
           mountPath: /tmp


### PR DESCRIPTION
Fixed issues:

https://github.com/kubernetes-incubator/metrics-server/issues/105
https://github.com/kubernetes-incubator/metrics-server/issues/97

For starting metrics-server +1.8