### PR TITLE
Import apiserver release-1.11 branch as constraint

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,7 +52,7 @@ required = ["k8s.io/kube-openapi/cmd/openapi-gen"]
 
 [[constraint]]
   name = "k8s.io/apiserver"
-  version = "kubernetes-1.11.0"
+  branch = "release-1.11"
 
 [[constraint]]
   name = "k8s.io/client-go"

--- a/vendor/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+++ b/vendor/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
@@ -74,7 +74,10 @@ func (a *mutatingDispatcher) Dispatch(ctx context.Context, attr *generic.Version
 	}
 
 	// convert attr.VersionedObject to the internal version in the underlying admission.Attributes
-	return a.plugin.scheme.Convert(attr.VersionedObject, attr.Attributes.GetObject(), nil)
+	if attr.VersionedObject != nil {
+		return a.plugin.scheme.Convert(attr.VersionedObject, attr.Attributes.GetObject(), nil)
+	}
+	return nil
 }
 
 // note that callAttrMutatingHook updates attr
@@ -106,6 +109,15 @@ func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *v1beta
 	if err != nil {
 		return apierrors.NewInternalError(err)
 	}
+	if len(patchObj) == 0 {
+		return nil
+	}
+
+	// if a non-empty patch was provided, and we have no object we can apply it to (e.g. a DELETE admission operation), error
+	if attr.VersionedObject == nil {
+		return apierrors.NewInternalError(fmt.Errorf("admission webhook %q attempted to modify the object, which is not supported for this operation", h.Name))
+	}
+
 	objJS, err := runtime.Encode(a.plugin.jsonSerializer, attr.VersionedObject)
 	if err != nil {
 		return apierrors.NewInternalError(err)

--- a/vendor/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
+++ b/vendor/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -160,6 +161,14 @@ func allHeaderValues(h http.Header, headerNames []string) []string {
 	return ret
 }
 
+func unescapeExtraKey(encodedKey string) string {
+	key, err := url.PathUnescape(encodedKey) // Decode %-encoded bytes.
+	if err != nil {
+		return encodedKey // Always record extra strings, even if malformed/unencoded.
+	}
+	return key
+}
+
 func newExtra(h http.Header, headerPrefixes []string) map[string][]string {
 	ret := map[string][]string{}
 
@@ -170,7 +179,7 @@ func newExtra(h http.Header, headerPrefixes []string) map[string][]string {
 				continue
 			}
 
-			extraKey := strings.ToLower(headerName[len(prefix):])
+			extraKey := unescapeExtraKey(strings.ToLower(headerName[len(prefix):]))
 			ret[extraKey] = append(ret[extraKey], vv...)
 		}
 	}

--- a/vendor/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
+++ b/vendor/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/golang/glog"
@@ -146,6 +147,14 @@ func WithImpersonation(handler http.Handler, a authorizer.Authorizer, s runtime.
 	})
 }
 
+func unescapeExtraKey(encodedKey string) string {
+	key, err := url.PathUnescape(encodedKey) // Decode %-encoded bytes.
+	if err != nil {
+		return encodedKey // Always record extra strings, even if malformed/unencoded.
+	}
+	return key
+}
+
 // buildImpersonationRequests returns a list of objectreferences that represent the different things we're requesting to impersonate.
 // Also includes a map[string][]string representing user.Info.Extra
 // Each request must be authorized against the current user before switching contexts.
@@ -175,7 +184,7 @@ func buildImpersonationRequests(headers http.Header) ([]v1.ObjectReference, erro
 		}
 
 		hasUserExtra = true
-		extraKey := strings.ToLower(headerName[len(authenticationv1.ImpersonateUserExtraHeaderPrefix):])
+		extraKey := unescapeExtraKey(strings.ToLower(headerName[len(authenticationv1.ImpersonateUserExtraHeaderPrefix):]))
 
 		// make a separate request for each extra value they're trying to set
 		for _, value := range values {

--- a/vendor/k8s.io/apiserver/pkg/server/options/authentication.go
+++ b/vendor/k8s.io/apiserver/pkg/server/options/authentication.go
@@ -160,7 +160,11 @@ func (s *DelegatingAuthenticationOptions) ApplyTo(c *server.AuthenticationInfo, 
 
 	clientCA, err := s.getClientCA()
 	if err != nil {
-		return err
+		if _, ignorable := err.(ignorableError); !ignorable {
+			return err
+		} else {
+			glog.Warning(err)
+		}
 	}
 	if err = c.ApplyClientCert(clientCA.ClientCA, servingInfo); err != nil {
 		return fmt.Errorf("unable to load client CA file: %v", err)
@@ -200,7 +204,11 @@ func (s *DelegatingAuthenticationOptions) ToAuthenticationConfig() (authenticato
 
 	clientCA, err := s.getClientCA()
 	if err != nil {
-		return authenticatorfactory.DelegatingAuthenticatorConfig{}, err
+		if _, ignorable := err.(ignorableError); !ignorable {
+			return authenticatorfactory.DelegatingAuthenticatorConfig{}, err
+		} else {
+			glog.Warning(err)
+		}
 	}
 	requestHeader, err := s.getRequestHeader()
 	if err != nil {
@@ -240,7 +248,7 @@ func (s *DelegatingAuthenticationOptions) getClientCA() (*ClientCertAuthenticati
 		return nil, err
 	}
 	if incluster == nil {
-		return nil, fmt.Errorf("cluster doesn't provide client-ca-file")
+		return &s.ClientCert, ignorableError{fmt.Errorf("cluster doesn't provide client-ca-file in configmap/%s in %s, so client certificate authentication to extension api-server won't work.", authenticationConfigMapName, authenticationConfigMapNamespace)}
 	}
 	return incluster, nil
 }
@@ -394,3 +402,5 @@ func (s *DelegatingAuthenticationOptions) newTokenAccessReview() (authentication
 
 	return client.TokenReviews(), nil
 }
+
+type ignorableError struct{ error }

--- a/vendor/k8s.io/apiserver/pkg/storage/etcd3/lease_manager.go
+++ b/vendor/k8s.io/apiserver/pkg/storage/etcd3/lease_manager.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd3
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+)
+
+// leaseManager is used to manage leases requested from etcd. If a new write
+// needs a lease that has similar expiration time to the previous one, the old
+// lease will be reused to reduce the overhead of etcd, since lease operations
+// are expensive. In the implementation, we only store one previous lease,
+// since all the events have the same ttl.
+type leaseManager struct {
+	client                  *clientv3.Client // etcd client used to grant leases
+	leaseMu                 sync.Mutex
+	prevLeaseID             clientv3.LeaseID
+	prevLeaseExpirationTime time.Time
+	// The period of time in seconds and percent of TTL that each lease is
+	// reused. The minimum of them is used to avoid unreasonably large
+	// numbers. We use var instead of const for testing purposes.
+	leaseReuseDurationSeconds int64
+	leaseReuseDurationPercent float64
+}
+
+// newDefaultLeaseManager creates a new lease manager using default setting.
+func newDefaultLeaseManager(client *clientv3.Client) *leaseManager {
+	return newLeaseManager(client, 60, 0.05)
+}
+
+// newLeaseManager creates a new lease manager with the number of buffered
+// leases, lease reuse duration in seconds and percentage. The percentage
+// value x means x*100%.
+func newLeaseManager(client *clientv3.Client, leaseReuseDurationSeconds int64, leaseReuseDurationPercent float64) *leaseManager {
+	return &leaseManager{
+		client: client,
+		leaseReuseDurationSeconds: leaseReuseDurationSeconds,
+		leaseReuseDurationPercent: leaseReuseDurationPercent,
+	}
+}
+
+// setLeaseReuseDurationSeconds is used for testing purpose. It is used to
+// reduce the extra lease duration to avoid unnecessary timeout in testing.
+func (l *leaseManager) setLeaseReuseDurationSeconds(duration int64) {
+	l.leaseMu.Lock()
+	defer l.leaseMu.Unlock()
+	l.leaseReuseDurationSeconds = duration
+}
+
+// GetLease returns a lease based on requested ttl: if the cached previous
+// lease can be reused, reuse it; otherwise request a new one from etcd.
+func (l *leaseManager) GetLease(ctx context.Context, ttl int64) (clientv3.LeaseID, error) {
+	now := time.Now()
+	l.leaseMu.Lock()
+	defer l.leaseMu.Unlock()
+	// check if previous lease can be reused
+	reuseDurationSeconds := l.getReuseDurationSecondsLocked(ttl)
+	valid := now.Add(time.Duration(ttl) * time.Second).Before(l.prevLeaseExpirationTime)
+	sufficient := now.Add(time.Duration(ttl+reuseDurationSeconds) * time.Second).After(l.prevLeaseExpirationTime)
+	if valid && sufficient {
+		return l.prevLeaseID, nil
+	}
+	// request a lease with a little extra ttl from etcd
+	ttl += reuseDurationSeconds
+	lcr, err := l.client.Lease.Grant(ctx, ttl)
+	if err != nil {
+		return clientv3.LeaseID(0), err
+	}
+	// cache the new lease id
+	l.prevLeaseID = lcr.ID
+	l.prevLeaseExpirationTime = now.Add(time.Duration(ttl) * time.Second)
+	return lcr.ID, nil
+}
+
+// getReuseDurationSecondsLocked returns the reusable duration in seconds
+// based on the configuration. Lock has to be acquired before calling this
+// function.
+func (l *leaseManager) getReuseDurationSecondsLocked(ttl int64) int64 {
+	reuseDurationSeconds := int64(l.leaseReuseDurationPercent * float64(ttl))
+	if reuseDurationSeconds > l.leaseReuseDurationSeconds {
+		reuseDurationSeconds = l.leaseReuseDurationSeconds
+	}
+	return reuseDurationSeconds
+}

--- a/vendor/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/vendor/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -29,14 +29,15 @@ import (
 	"k8s.io/apiserver/pkg/storage/value"
 )
 
-var (
-	// The short keepalive timeout and interval have been chosen to aggressively
-	// detect a failed etcd server without introducing much overhead.
-	keepaliveTime    = 30 * time.Second
-	keepaliveTimeout = 10 * time.Second
-	// dialTimeout is the timeout for failing to establish a connection.
-	dialTimeout = 10 * time.Second
-)
+// The short keepalive timeout and interval have been chosen to aggressively
+// detect a failed etcd server without introducing much overhead.
+const keepaliveTime = 30 * time.Second
+const keepaliveTimeout = 10 * time.Second
+
+// dialTimeout is the timeout for failing to establish a connection.
+// It is set to 20 seconds as times shorter than that will cause TLS connections to fail
+// on heavily loaded arm64 CPUs (issue #64649)
+const dialTimeout = 20 * time.Second
 
 func newETCD3Storage(c storagebackend.Config) (storage.Interface, DestroyFunc, error) {
 	tlsInfo := transport.TLSInfo{

--- a/vendor/k8s.io/apiserver/pkg/util/feature/feature_gate.go
+++ b/vendor/k8s.io/apiserver/pkg/util/feature/feature_gate.go
@@ -191,7 +191,7 @@ func (f *featureGate) Set(value string) error {
 	f.known.Store(known)
 	f.enabled.Store(enabled)
 
-	glog.Infof("feature gates: %v", enabled)
+	glog.V(1).Infof("feature gates: %v", enabled)
 	return nil
 }
 
@@ -227,7 +227,7 @@ func (f *featureGate) SetFromMap(m map[string]bool) error {
 	f.known.Store(known)
 	f.enabled.Store(enabled)
 
-	glog.Infof("feature gates: %v", f.enabled)
+	glog.V(1).Infof("feature gates: %v", f.enabled)
 	return nil
 }
 

--- a/vendor/k8s.io/apiserver/plugin/pkg/audit/buffered/buffered.go
+++ b/vendor/k8s.io/apiserver/plugin/pkg/audit/buffered/buffered.go
@@ -102,6 +102,7 @@ type bufferedBackend struct {
 var _ audit.Backend = &bufferedBackend{}
 
 // NewBackend returns a buffered audit backend that wraps delegate backend.
+// Buffered backend automatically runs and shuts down the delegate backend.
 func NewBackend(delegate audit.Backend, config BatchConfig) audit.Backend {
 	var throttle flowcontrol.RateLimiter
 	if config.ThrottleEnable {

--- a/vendor/k8s.io/apiserver/plugin/pkg/audit/truncate/truncate.go
+++ b/vendor/k8s.io/apiserver/plugin/pkg/audit/truncate/truncate.go
@@ -62,6 +62,7 @@ type backend struct {
 var _ audit.Backend = &backend{}
 
 // NewBackend returns a new truncating backend, using configuration passed in the parameters.
+// Truncate backend automatically runs and shut downs the delegate backend.
 func NewBackend(delegateBackend audit.Backend, config Config, groupVersion schema.GroupVersion) audit.Backend {
 	return &backend{
 		delegateBackend: delegateBackend,
@@ -128,12 +129,11 @@ func truncate(e *auditinternal.Event) *auditinternal.Event {
 }
 
 func (b *backend) Run(stopCh <-chan struct{}) error {
-	// Nothing to do here
-	return nil
+	return b.delegateBackend.Run(stopCh)
 }
 
 func (b *backend) Shutdown() {
-	// Nothing to do here
+	b.delegateBackend.Shutdown()
 }
 
 func (b *backend) calcSize(e *auditinternal.Event) (int64, error) {


### PR DESCRIPTION
Updating apiserver dependency to pull from release-1.11 to bring in a fix for running metrics server in clusters with client authentication mechanisms other cert based.

Refer https://github.com/kubernetes/kubernetes/issues/65724 for more details