### PR TITLE
Modify package name in reststorage.go

### DIFF
--- a/pkg/storage/nodemetrics/reststorage.go
+++ b/pkg/storage/nodemetrics/reststorage.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package app
+package nodemetrics
 
 import (
 	"context"

--- a/pkg/storage/podmetrics/reststorage.go
+++ b/pkg/storage/podmetrics/reststorage.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package app
+package podmetrics
 
 import (
 	"context"


### PR DESCRIPTION
Modify the package name using directory name like other go files
in this project. The current package name is a little confused.