### PR TITLE
Use the earliest possible timestamp for metric points

### DIFF
--- a/pkg/provider/sinkprov_test.go
+++ b/pkg/provider/sinkprov_test.go
@@ -150,8 +150,8 @@ var _ = Describe("In-memory Sink Provider", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		By("verifying that the timestamp is the largest time amongst all containers")
-		Expect(ts).To(Equal(now.Add(500 * time.Millisecond)))
+		By("verifying that the timestamp is the smallest time amongst all containers")
+		Expect(ts).To(Equal(now.Add(400 * time.Millisecond)))
 
 		By("verifying that all containers have data")
 		Expect(containerMetrics).To(ConsistOf(

--- a/pkg/storage/nodemetrics/reststorage.go
+++ b/pkg/storage/nodemetrics/reststorage.go
@@ -35,6 +35,12 @@ import (
 	_ "k8s.io/metrics/pkg/apis/metrics/install"
 )
 
+// kubernetesCadvisorWindow is the max window used by cAdvisor for calculating
+// CPU usage rate.  While it can vary, it's no more than this number, but may be
+// as low as half this number (when working with no backoff).  It would be really
+// nice if the kubelet told us this in the summary API...
+var kubernetesCadvisorWindow = 30 * time.Second
+
 type MetricStorage struct {
 	groupResource schema.GroupResource
 	prov          provider.NodeMetricsProvider
@@ -122,7 +128,7 @@ func (m *MetricStorage) getNodeMetrics(name string) (*metrics.NodeMetrics, error
 			CreationTimestamp: metav1.NewTime(time.Now()),
 		},
 		Timestamp: metav1.NewTime(ts),
-		Window:    metav1.Duration{Duration: time.Minute},
+		Window:    metav1.Duration{Duration: kubernetesCadvisorWindow},
 		Usage:     usage,
 	}, nil
 }

--- a/pkg/storage/podmetrics/reststorage.go
+++ b/pkg/storage/podmetrics/reststorage.go
@@ -37,6 +37,12 @@ import (
 	_ "k8s.io/metrics/pkg/apis/metrics/install"
 )
 
+// kubernetesCadvisorWindow is the max window used by cAdvisor for calculating
+// CPU usage rate.  While it can vary, it's no more than this number, but may be
+// as low as half this number (when working with no backoff).  It would be really
+// nice if the kubelet told us this in the summary API...
+var kubernetesCadvisorWindow = 30 * time.Second
+
 type MetricStorage struct {
 	groupResource schema.GroupResource
 	prov          provider.PodMetricsProvider
@@ -142,7 +148,7 @@ func (m *MetricStorage) getPodMetrics(pod *v1.Pod) (*metrics.PodMetrics, error) 
 		// TODO(directxman12): figure out what the right value is here,
 		// we don't get the actual window from cAdvisor, so we could just
 		// plumb down metric resolution, but that wouldn't be actually correct.
-		Window:     metav1.Duration{Duration: time.Minute},
+		Window:     metav1.Duration{Duration: kubernetesCadvisorWindow},
 		Containers: containerMetrics,
 	}
 


### PR DESCRIPTION
This ensures that we're using the earliest possible timestamp for metrics points when aggregating timestamps together (e.g. cpu+memory or multiple containers in a pod), which means that we can safely use the timestamp and window to determine if the given point is tainted by pod initialization.

This also lowers the hardcoded window from 1 minute to 30s, to reflect what the max it could actually be now that we're collecting from cAdvisor directly (see the commit message for an explanation of this time).  