### PR TITLE
A few more changes for external provider support

### DIFF
--- a/cmd/metrics-server/app/start.go
+++ b/cmd/metrics-server/app/start.go
@@ -33,7 +33,7 @@ import (
 	"github.com/kubernetes-incubator/metrics-server/pkg/apiserver"
 	genericmetrics "github.com/kubernetes-incubator/metrics-server/pkg/apiserver/generic"
 	"github.com/kubernetes-incubator/metrics-server/pkg/manager"
-	"github.com/kubernetes-incubator/metrics-server/pkg/provider"
+	"github.com/kubernetes-incubator/metrics-server/pkg/provider/sink"
 	"github.com/kubernetes-incubator/metrics-server/pkg/sources"
 	"github.com/kubernetes-incubator/metrics-server/pkg/sources/summary"
 )
@@ -190,7 +190,7 @@ func (o MetricsServerOptions) Run(stopCh <-chan struct{}) error {
 	sourceManager := sources.NewSourceManager(sourceProvider, scrapeTimeout)
 
 	// set up the in-memory sink and provider
-	metricSink, metricsProvider := provider.NewSinkProvider()
+	metricSink, metricsProvider := sink.NewSinkProvider()
 
 	// set up the general manager
 	manager.RegisterDurationMetrics(o.MetricResolution)

--- a/pkg/provider/interfaces.go
+++ b/pkg/provider/interfaces.go
@@ -30,15 +30,16 @@ type MetricsProvider interface {
 
 // PodMetricsProvider knows how to fetch metrics for the containers in a pod.
 type PodMetricsProvider interface {
-	// GetContainerMetrics gets the latest metrics for all containers in a pod,
+	// GetContainerMetrics gets the latest metrics for all containers in each listed pod,
 	// returning both the metrics and the associated collection timestamp.
-	// It will return an errors.NotFound if the metrics aren't found.
-	GetContainerMetrics(pod apitypes.NamespacedName) (time.Time, []metrics.ContainerMetrics, error)
+	// If a pod is missing, the container metrics should be nil for that pod.
+	GetContainerMetrics(pods ...apitypes.NamespacedName) ([]time.Time, [][]metrics.ContainerMetrics, error)
 }
 
 // NodeMetricsProvider knows how to fetch metrics for a node.
 type NodeMetricsProvider interface {
-	// GetNodeMetrics gets the latest metrics for the given node,
+	// GetNodeMetrics gets the latest metrics for the given nodes,
 	// returning both the metrics and the associated collection timestamp.
-	GetNodeMetrics(node string) (time.Time, corev1.ResourceList, error)
+	// If a node is missing, the resourcelist should be nil for that node.
+	GetNodeMetrics(nodes ...string) ([]time.Time, []corev1.ResourceList, error)
 }

--- a/pkg/provider/interfaces.go
+++ b/pkg/provider/interfaces.go
@@ -28,12 +28,30 @@ type MetricsProvider interface {
 	NodeMetricsProvider
 }
 
+// TimeSpan represents the timing information for a metric, which was
+// potentially calculated over some window of time (e.g. for CPU usage rate).
+type TimeInfo struct {
+	// NB: we consider the earliest timestamp amongst multiple containers
+	// for the purposes of determining if a metric is tained by a time
+	// period, like pod startup (used by things like the HPA).
+
+	// Timestamp is the time at which the metrics were initially collected.
+	// In the case of a rate metric, it should be the timestamp of the last
+	// data point used in the calculation.  If it represents multiple metric
+	// points, it should be the earliest such timestamp from all of the points.
+	Timestamp time.Time
+
+	// Window represents the window used to calculate rate metrics associated
+	// with this timestamp.
+	Window time.Duration
+}
+
 // PodMetricsProvider knows how to fetch metrics for the containers in a pod.
 type PodMetricsProvider interface {
 	// GetContainerMetrics gets the latest metrics for all containers in each listed pod,
 	// returning both the metrics and the associated collection timestamp.
 	// If a pod is missing, the container metrics should be nil for that pod.
-	GetContainerMetrics(pods ...apitypes.NamespacedName) ([]time.Time, [][]metrics.ContainerMetrics, error)
+	GetContainerMetrics(pods ...apitypes.NamespacedName) ([]TimeInfo, [][]metrics.ContainerMetrics, error)
 }
 
 // NodeMetricsProvider knows how to fetch metrics for a node.
@@ -41,5 +59,5 @@ type NodeMetricsProvider interface {
 	// GetNodeMetrics gets the latest metrics for the given nodes,
 	// returning both the metrics and the associated collection timestamp.
 	// If a node is missing, the resourcelist should be nil for that node.
-	GetNodeMetrics(nodes ...string) ([]time.Time, []corev1.ResourceList, error)
+	GetNodeMetrics(nodes ...string) ([]TimeInfo, []corev1.ResourceList, error)
 }

--- a/pkg/provider/sink/sinkprov.go
+++ b/pkg/provider/sink/sinkprov.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package provider
+package sink
 
 import (
 	"fmt"
@@ -23,6 +23,7 @@ import (
 	apitypes "k8s.io/apimachinery/pkg/types"
 	metrics "k8s.io/metrics/pkg/apis/metrics"
 
+	"github.com/kubernetes-incubator/metrics-server/pkg/provider"
 	"github.com/kubernetes-incubator/metrics-server/pkg/sink"
 	"github.com/kubernetes-incubator/metrics-server/pkg/sources"
 )
@@ -35,7 +36,7 @@ type sinkMetricsProvider struct {
 }
 
 // NewSinkProvider returns a MetricSink that feeds into a MetricsProvider.
-func NewSinkProvider() (sink.MetricSink, MetricsProvider) {
+func NewSinkProvider() (sink.MetricSink, provider.MetricsProvider) {
 	prov := &sinkMetricsProvider{}
 	return prov, prov
 }

--- a/pkg/provider/sink/sinkprov_test.go
+++ b/pkg/provider/sink/sinkprov_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package provider_test
+package sink_test
 
 import (
 	"testing"
@@ -25,7 +25,8 @@ import (
 	apitypes "k8s.io/apimachinery/pkg/types"
 	metrics "k8s.io/metrics/pkg/apis/metrics"
 
-	. "github.com/kubernetes-incubator/metrics-server/pkg/provider"
+	"github.com/kubernetes-incubator/metrics-server/pkg/provider"
+	. "github.com/kubernetes-incubator/metrics-server/pkg/provider/sink"
 	"github.com/kubernetes-incubator/metrics-server/pkg/sink"
 	"github.com/kubernetes-incubator/metrics-server/pkg/sources"
 )
@@ -46,7 +47,7 @@ func newMilliPoint(ts time.Time, cpu, memory int64) sources.MetricsPoint {
 var _ = Describe("In-memory Sink Provider", func() {
 	var (
 		batch    *sources.MetricsBatch
-		prov     MetricsProvider
+		prov     provider.MetricsProvider
 		provSink sink.MetricSink
 		now      time.Time
 	)

--- a/pkg/provider/sink/sinkprov_test.go
+++ b/pkg/provider/sink/sinkprov_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/kubernetes-incubator/metrics-server/pkg/sources"
 )
 
+var defaultWindow = 30 * time.Second
+
 func TestSourceManager(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Provider/Sink Suite")
@@ -156,7 +158,7 @@ var _ = Describe("In-memory Sink Provider", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("verifying that the timestamp is the smallest time amongst all containers")
-		Expect(ts).To(ConsistOf(now.Add(400 * time.Millisecond)))
+		Expect(ts).To(ConsistOf(provider.TimeInfo{Timestamp: now.Add(400 * time.Millisecond), Window: defaultWindow}))
 
 		By("verifying that all containers have data")
 		Expect(containerMetrics).To(Equal(
@@ -195,8 +197,8 @@ var _ = Describe("In-memory Sink Provider", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		By("verifying that the timestamp is the largest time amongst all containers")
-		Expect(ts).To(Equal([]time.Time{now.Add(500 * time.Millisecond), {}}))
+		By("verifying that the timestamp is the smallest time amongst all containers")
+		Expect(ts).To(Equal([]provider.TimeInfo{{Timestamp: now.Add(400 * time.Millisecond), Window: defaultWindow}, {}}))
 
 		By("verifying that all present containers have data")
 		Expect(containerMetrics).To(Equal(
@@ -231,8 +233,8 @@ var _ = Describe("In-memory Sink Provider", func() {
 		ts, nodeMetrics, err := prov.GetNodeMetrics("node1", "node2")
 		Expect(err).NotTo(HaveOccurred())
 
-		By("verifying that the timestamp is the largest time amongst all containers")
-		Expect(ts).To(Equal([]time.Time{now.Add(100 * time.Millisecond), now.Add(200 * time.Millisecond)}))
+		By("verifying that the timestamp is the smallest time amongst all containers")
+		Expect(ts).To(Equal([]provider.TimeInfo{{Timestamp: now.Add(100 * time.Millisecond), Window: defaultWindow}, {Timestamp: now.Add(200 * time.Millisecond), Window: defaultWindow}}))
 
 		By("verifying that all nodes have data")
 		Expect(nodeMetrics).To(Equal(
@@ -257,8 +259,8 @@ var _ = Describe("In-memory Sink Provider", func() {
 		ts, nodeMetrics, err := prov.GetNodeMetrics("node1", "node2", "node42")
 		Expect(err).NotTo(HaveOccurred())
 
-		By("verifying that the timestamp is the largest time amongst all containers")
-		Expect(ts).To(Equal([]time.Time{now.Add(100 * time.Millisecond), now.Add(200 * time.Millisecond), {}}))
+		By("verifying that the timestamp is the smallest time amongst all containers")
+		Expect(ts).To(Equal([]provider.TimeInfo{{Timestamp: now.Add(100 * time.Millisecond), Window: defaultWindow}, {Timestamp: now.Add(200 * time.Millisecond), Window: defaultWindow}, {}}))
 
 		By("verifying that all present nodes have data")
 		Expect(nodeMetrics).To(Equal(

--- a/pkg/storage/nodemetrics/reststorage.go
+++ b/pkg/storage/nodemetrics/reststorage.go
@@ -35,12 +35,6 @@ import (
 	_ "k8s.io/metrics/pkg/apis/metrics/install"
 )
 
-// kubernetesCadvisorWindow is the max window used by cAdvisor for calculating
-// CPU usage rate.  While it can vary, it's no more than this number, but may be
-// as low as half this number (when working with no backoff).  It would be really
-// nice if the kubelet told us this in the summary API...
-var kubernetesCadvisorWindow = 30 * time.Second
-
 type MetricStorage struct {
 	groupResource schema.GroupResource
 	prov          provider.NodeMetricsProvider
@@ -141,8 +135,8 @@ func (m *MetricStorage) getNodeMetrics(names ...string) ([]metrics.NodeMetrics, 
 				Name:              name,
 				CreationTimestamp: metav1.NewTime(time.Now()),
 			},
-			Timestamp: metav1.NewTime(timestamps[i]),
-			Window:    metav1.Duration{Duration: kubernetesCadvisorWindow},
+			Timestamp: metav1.NewTime(timestamps[i].Timestamp),
+			Window:    metav1.Duration{Duration: timestamps[i].Window},
 			Usage:     usages[i],
 		})
 	}

--- a/pkg/storage/nodemetrics/reststorage.go
+++ b/pkg/storage/nodemetrics/reststorage.go
@@ -89,48 +89,65 @@ func (m *MetricStorage) List(ctx context.Context, options *metainternalversion.L
 		return labelSelector.Matches(labels.Set(node.Labels))
 	})
 	if err != nil {
-		errMsg := fmt.Errorf("Error while listing nodes: %v", err)
+		errMsg := fmt.Errorf("Error while listing nodes for selector %v: %v", labelSelector, err)
 		glog.Error(errMsg)
 		return &metrics.NodeMetricsList{}, errMsg
 	}
 
-	res := metrics.NodeMetricsList{}
-	for _, node := range nodes {
-		nodeMetrics, err := m.getNodeMetrics(node.Name)
-		if err != nil {
-			glog.Errorf("unable to fetch node metrics for node %q: %v", node.Name, err)
-			continue
-		}
-		res.Items = append(res.Items, *nodeMetrics)
+	names := make([]string, len(nodes))
+	for i, node := range nodes {
+		names[i] = node.Name
 	}
-	return &res, nil
+
+	metricsItems, err := m.getNodeMetrics(names...)
+	if err != nil {
+		errMsg := fmt.Errorf("Error while fetching node metrics for selector %v: %v", labelSelector, err)
+		glog.Error(errMsg)
+		return &metrics.NodeMetricsList{}, errMsg
+	}
+
+	return &metrics.NodeMetricsList{Items: metricsItems}, nil
 }
 
 func (m *MetricStorage) Get(ctx context.Context, name string, opts *metav1.GetOptions) (runtime.Object, error) {
 	nodeMetrics, err := m.getNodeMetrics(name)
+	if err == nil && len(nodeMetrics) == 0 {
+		err = fmt.Errorf("no metrics known for node %q", name)
+	}
 	if err != nil {
 		glog.Errorf("unable to fetch node metrics for node %q: %v", name, err)
 		return nil, errors.NewNotFound(m.groupResource, name)
 	}
 
-	return nodeMetrics, nil
+	return &nodeMetrics[0], nil
 }
 
-func (m *MetricStorage) getNodeMetrics(name string) (*metrics.NodeMetrics, error) {
-	ts, usage, err := m.prov.GetNodeMetrics(name)
+func (m *MetricStorage) getNodeMetrics(names ...string) ([]metrics.NodeMetrics, error) {
+	timestamps, usages, err := m.prov.GetNodeMetrics(names...)
 	if err != nil {
 		return nil, err
 	}
 
-	return &metrics.NodeMetrics{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              name,
-			CreationTimestamp: metav1.NewTime(time.Now()),
-		},
-		Timestamp: metav1.NewTime(ts),
-		Window:    metav1.Duration{Duration: kubernetesCadvisorWindow},
-		Usage:     usage,
-	}, nil
+	res := make([]metrics.NodeMetrics, 0, len(names))
+
+	for i, name := range names {
+		if usages[i] == nil {
+			glog.Errorf("unable to fetch node metrics for node %q: no metrics known for node", name)
+
+			continue
+		}
+		res = append(res, metrics.NodeMetrics{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				CreationTimestamp: metav1.NewTime(time.Now()),
+			},
+			Timestamp: metav1.NewTime(timestamps[i]),
+			Window:    metav1.Duration{Duration: kubernetesCadvisorWindow},
+			Usage:     usages[i],
+		})
+	}
+
+	return res, nil
 }
 
 func (m *MetricStorage) NamespaceScoped() bool {

--- a/pkg/storage/podmetrics/reststorage.go
+++ b/pkg/storage/podmetrics/reststorage.go
@@ -37,12 +37,6 @@ import (
 	_ "k8s.io/metrics/pkg/apis/metrics/install"
 )
 
-// kubernetesCadvisorWindow is the max window used by cAdvisor for calculating
-// CPU usage rate.  While it can vary, it's no more than this number, but may be
-// as low as half this number (when working with no backoff).  It would be really
-// nice if the kubelet told us this in the summary API...
-var kubernetesCadvisorWindow = 30 * time.Second
-
 type MetricStorage struct {
 	groupResource schema.GroupResource
 	prov          provider.PodMetricsProvider
@@ -157,11 +151,8 @@ func (m *MetricStorage) getPodMetrics(pods ...*v1.Pod) ([]metrics.PodMetrics, er
 				Namespace:         pod.Namespace,
 				CreationTimestamp: metav1.NewTime(time.Now()),
 			},
-			Timestamp: metav1.NewTime(timestamps[i]),
-			// TODO(directxman12): figure out what the right value is here,
-			// we don't get the actual window from cAdvisor, so we could just
-			// plumb down metric resolution, but that wouldn't be actually correct.
-			Window:     metav1.Duration{Duration: kubernetesCadvisorWindow},
+			Timestamp:  metav1.NewTime(timestamps[i].Timestamp),
+			Window:     metav1.Duration{Duration: timestamps[i].Window},
 			Containers: containerMetrics[i],
 		})
 	}

--- a/pkg/storage/podmetrics/reststorage.go
+++ b/pkg/storage/podmetrics/reststorage.go
@@ -86,21 +86,19 @@ func (m *MetricStorage) List(ctx context.Context, options *metainternalversion.L
 	namespace := genericapirequest.NamespaceValue(ctx)
 	pods, err := m.podLister.Pods(namespace).List(labelSelector)
 	if err != nil {
-		errMsg := fmt.Errorf("Error while listing pods for selector %v: %v", labelSelector, err)
+		errMsg := fmt.Errorf("Error while listing pods for selector %v in namespace %q: %v", labelSelector, namespace, err)
 		glog.Error(errMsg)
 		return &metrics.PodMetricsList{}, errMsg
 	}
 
-	res := metrics.PodMetricsList{}
-	for _, pod := range pods {
-		podMetrics, err := m.getPodMetrics(pod)
-		if err != nil {
-			glog.Errorf("unable to fetch pod metrics for pod %s/%s: %v", pod.Namespace, pod.Name, err)
-			continue
-		}
-		res.Items = append(res.Items, *podMetrics)
+	metricsItems, err := m.getPodMetrics(pods...)
+	if err != nil {
+		errMsg := fmt.Errorf("Error while fetching pod metrics for selector %v in namespace %q: %v", labelSelector, namespace, err)
+		glog.Error(errMsg)
+		return &metrics.PodMetricsList{}, errMsg
 	}
-	return &res, nil
+
+	return &metrics.PodMetricsList{Items: metricsItems}, nil
 }
 
 // Getter interface
@@ -122,36 +120,51 @@ func (m *MetricStorage) Get(ctx context.Context, name string, opts *metav1.GetOp
 	}
 
 	podMetrics, err := m.getPodMetrics(pod)
+	if err == nil && len(podMetrics) == 0 {
+		err = fmt.Errorf("no metrics known for pod \"%s/%s\"", pod.Namespace, pod.Name)
+	}
 	if err != nil {
 		glog.Errorf("unable to fetch pod metrics for pod %s/%s: %v", pod.Namespace, pod.Name, err)
 		return nil, errors.NewNotFound(m.groupResource, fmt.Sprintf("%v/%v", namespace, name))
 	}
-	return podMetrics, nil
+	return &podMetrics[0], nil
 }
 
-func (m *MetricStorage) getPodMetrics(pod *v1.Pod) (*metrics.PodMetrics, error) {
-	ts, containerMetrics, err := m.prov.GetContainerMetrics(apitypes.NamespacedName{
-		Name:      pod.Name,
-		Namespace: pod.Namespace,
-	})
+func (m *MetricStorage) getPodMetrics(pods ...*v1.Pod) ([]metrics.PodMetrics, error) {
+	namespacedNames := make([]apitypes.NamespacedName, len(pods))
+	for i, pod := range pods {
+		namespacedNames[i] = apitypes.NamespacedName{
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+		}
+	}
+	timestamps, containerMetrics, err := m.prov.GetContainerMetrics(namespacedNames...)
 	if err != nil {
 		return nil, err
 	}
 
-	res := &metrics.PodMetrics{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              pod.Name,
-			Namespace:         pod.Namespace,
-			CreationTimestamp: metav1.NewTime(time.Now()),
-		},
-		Timestamp: metav1.NewTime(ts),
-		// TODO(directxman12): figure out what the right value is here,
-		// we don't get the actual window from cAdvisor, so we could just
-		// plumb down metric resolution, but that wouldn't be actually correct.
-		Window:     metav1.Duration{Duration: kubernetesCadvisorWindow},
-		Containers: containerMetrics,
-	}
+	res := make([]metrics.PodMetrics, 0, len(pods))
 
+	for i, pod := range pods {
+		if containerMetrics[i] == nil {
+			glog.Errorf("unable to fetch pod metrics for pod %s/%s: no metrics known for pod", pod.Namespace, pod.Name)
+			continue
+		}
+
+		res = append(res, metrics.PodMetrics{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              pod.Name,
+				Namespace:         pod.Namespace,
+				CreationTimestamp: metav1.NewTime(time.Now()),
+			},
+			Timestamp: metav1.NewTime(timestamps[i]),
+			// TODO(directxman12): figure out what the right value is here,
+			// we don't get the actual window from cAdvisor, so we could just
+			// plumb down metric resolution, but that wouldn't be actually correct.
+			Window:     metav1.Duration{Duration: kubernetesCadvisorWindow},
+			Containers: containerMetrics[i],
+		})
+	}
 	return res, nil
 }
 


### PR DESCRIPTION
This includes a few more changes for consuming this as a library, namely separating packages out to make it easier to just pull in the packages needed, fetching multiple points at once, and returning the window from the provider itself.