### PR TITLE
Fix cross compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,19 +97,21 @@ container-only-%: _output/$(ARCH)/metrics-server tmpdir
 # -----------------------------
 
 # do the actual push for official images
-do-push-%:
+do-push:
 	# push with main tag
-	docker push $(PREFIX)/metrics-server-$*:$(VERSION)
+	docker push $(PREFIX)/metrics-server-$(ARCH):$(VERSION)
 
 	# push alternate tags
 ifeq ($(ARCH),amd64)
 	# TODO: Remove this and push the manifest list as soon as it's working
-	docker tag $(PREFIX)/metrics-server-$*:$(VERSION) $(PREFIX)/metrics-server:$(VERSION)
+	docker tag $(PREFIX)/metrics-server-$(ARCH):$(VERSION) $(PREFIX)/metrics-server:$(VERSION)
 	docker push $(PREFIX)/metrics-server:$(VERSION)
 endif
 
 # do build and then push a given official image
-sub-push-%: container-% do-push-% ;
+sub-push-%:
+	$(MAKE) ARCH=$* PREFIX=$(PREFIX) VERSION=$(VERSION) container
+	$(MAKE) ARCH=$* PREFIX=$(PREFIX) VERSION=$(VERSION) do-push
 
 # do build and then push all official images
 push: gcr-login $(addprefix sub-push-,$(ALL_ARCHITECTURES)) ;


### PR DESCRIPTION
`sub-push` needs to call sub make with changing ARCH. 
Using targets does not work because architecture is templated by global ARCH variable that does not change.

Solution based on heapster https://github.com/kubernetes/heapster/blob/master/Makefile#L97

/cc @DirectXMan12 
I will cherry pick this to v0.3.0 so releasing patches will work.