### PR TITLE
Don't discard node results on error

### DIFF
--- a/cmd/metrics-server/app/start.go
+++ b/cmd/metrics-server/app/start.go
@@ -195,9 +195,6 @@ func (o MetricsServerOptions) Run(stopCh <-chan struct{}) error {
 	// set up the general manager
 	manager.RegisterDurationMetrics(o.MetricResolution)
 	mgr := manager.NewManager(sourceManager, metricSink, o.MetricResolution)
-	if err != nil {
-		return fmt.Errorf("unable to create main manager: %v", err)
-	}
 
 	// inject the providers into the config
 	config.ProviderConfig.Node = metricsProvider

--- a/pkg/sources/interfaces.go
+++ b/pkg/sources/interfaces.go
@@ -60,7 +60,9 @@ type MetricsPoint struct {
 // It is expected that the batch returned contains unique values (i.e. it does not return
 // the same node, pod, or container as any other source).
 type MetricSource interface {
-	// Collect fetches a batch of metrics.  It may return both a partial result and an error.
+	// Collect fetches a batch of metrics.  It may return both a partial result and an error,
+	// and non-nil results thus must be well-formed and meaningful even when accompanied by 
+	// and error.
 	Collect(context.Context) (*MetricsBatch, error)
 	// Name names the metrics source for identification purposes
 	Name() string

--- a/pkg/sources/manager.go
+++ b/pkg/sources/manager.go
@@ -136,6 +136,10 @@ func (m *sourceManager) Collect(baseCtx context.Context) (*MetricsBatch, error) 
 		srcBatch := <-responseChannel
 		if err != nil {
 			errs = append(errs, err)
+			// NB: partial node results are still worth saving, so
+			// don't skip storing results if we got an error
+		}
+		if srcBatch == nil {
 			continue
 		}
 


### PR DESCRIPTION
It's possible for the summary provider to return errors and partial
results.  This is explicitly listed in the documentation for the Source
interface.  We shouldn't discard partial results just because they're
partial, otherwise we'll end up discarding a node's worth of results
because of an error collecting for one pod.

This now also makes sure that we discard individual pods if any container is
missing metrics, so that the HPA can properly detect those metrics as missing.