### PR TITLE
Fix missing flags for starting metrics-server issue #97

### DIFF
--- a/deploy/1.8+/metrics-server-deployment.yaml
+++ b/deploy/1.8+/metrics-server-deployment.yaml
@@ -31,6 +31,9 @@ spec:
       - name: metrics-server
         image: k8s.gcr.io/metrics-server-amd64:v0.3.0
         imagePullPolicy: Always
+        command:
+          - /metrics-server
+          - --source=kubernetes.summary_api:https://kubernetes.default
         volumeMounts:
         - name: tmp-dir
           mountPath: /tmp


### PR DESCRIPTION
The only caveat is that if you update this command in place you must restart the metric-server pod so that the TLS handshake can happen per issue comment here https://github.com/kubernetes-incubator/metrics-server/issues/97#issuecomment-413891946

Fixed issues:

#105
#97

For starting metrics-server +1.8