### PR TITLE
Update deployment files to v0.3.1

### DIFF
--- a/deploy/1.8+/metrics-server-deployment.yaml
+++ b/deploy/1.8+/metrics-server-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         emptyDir: {}
       containers:
       - name: metrics-server
-        image: k8s.gcr.io/metrics-server-amd64:v0.3.0
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.1
         imagePullPolicy: Always
         volumeMounts:
         - name: tmp-dir


### PR DESCRIPTION
When we release v0.3.1 during the Kubernetes 1.12 release, we forgot
to update the deployment files in the metrics-server repo as well.

This updates them.