### PR TITLE
Change DefaultAddressTypePriority

### DIFF
--- a/pkg/sources/summary/addrs.go
+++ b/pkg/sources/summary/addrs.go
@@ -26,9 +26,6 @@ var (
 	// In general, we prefer overrides to others, internal to external,
 	// and DNS to IPs.
 	DefaultAddressTypePriority = []corev1.NodeAddressType{
-		// --override-hostname
-		corev1.NodeHostName,
-
 		// internal, preferring DNS if reported
 		corev1.NodeInternalDNS,
 		corev1.NodeInternalIP,
@@ -36,6 +33,8 @@ var (
 		// external, preferring DNS if reported
 		corev1.NodeExternalDNS,
 		corev1.NodeExternalIP,
+
+		corev1.NodeHostName,
 	}
 )
 


### PR DESCRIPTION
By default, the pod cannot access Node via hostname：

“unable to fully collect metrics: unable to fully scrape metrics from source kubelet_summary:master: unable to fetch metrics from Kubelet master (master): Get http://master:10255/stats/summary/: dial tcp: i/o timeout"

So I suggest to change the DefaultAddressTypePriority.