### PR TITLE
Fix typo: kubelets -> kubelet

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Additionally, Metrics Server defines a number of flags for configuring its
 behavior:
 
 - `--metric-resolution=<duration>`: the interval at which metrics will be
-  scraped from Kubelets (defaults to 60s).
+  scraped from Kubelet (defaults to 60s).
 
 - `--kubelet-insecure-tls`: skip verifying Kubelet CA certificates.  Not
   recommended for production usage, but can be useful in test clusters

--- a/cmd/metrics-server/app/start.go
+++ b/cmd/metrics-server/app/start.go
@@ -56,10 +56,10 @@ func NewCommandStartMetricsServer(out, errOut io.Writer, stopCh <-chan struct{})
 	flags := cmd.Flags()
 	flags.DurationVar(&o.MetricResolution, "metric-resolution", o.MetricResolution, "The resolution at which metrics-server will retain metrics.")
 
-	flags.BoolVar(&o.InsecureKubeletTLS, "kubelet-insecure-tls", o.InsecureKubeletTLS, "Do not verify CA of serving certificates presented by Kubelets.  For testing purposes only.")
+	flags.BoolVar(&o.InsecureKubeletTLS, "kubelet-insecure-tls", o.InsecureKubeletTLS, "Do not verify CA of serving certificates presented by Kubelet.  For testing purposes only.")
 	flags.BoolVar(&o.DeprecatedCompletelyInsecureKubelet, "deprecated-kubelet-completely-insecure", o.DeprecatedCompletelyInsecureKubelet, "Do not use any encryption, authorization, or authentication when communicating with the Kubelet.")
-	flags.IntVar(&o.KubeletPort, "kubelet-port", o.KubeletPort, "The port to use to connect to Kubelets.")
-	flags.StringVar(&o.Kubeconfig, "kubeconfig", o.Kubeconfig, "The path to the kubeconfig used to connect to the Kubernetes API server and the Kubelets (defaults to in-cluster config)")
+	flags.IntVar(&o.KubeletPort, "kubelet-port", o.KubeletPort, "The port to use to connect to Kubelet.")
+	flags.StringVar(&o.Kubeconfig, "kubeconfig", o.Kubeconfig, "The path to the kubeconfig used to connect to the Kubernetes API server and the Kubelet (defaults to in-cluster config)")
 	flags.StringSliceVar(&o.KubeletPreferredAddressTypes, "kubelet-preferred-address-types", o.KubeletPreferredAddressTypes, "The priority of node address types to use when determining which address to use to connect to a particular node")
 
 	flags.MarkDeprecated("deprecated-kubelet-completely-insecure", "This is rarely the right option, since it leaves kubelet communication completely insecure.  If you encounter auth errors, make sure you've enabled token webhook auth on the Kubelet, and if you're in a test cluster with self-signed Kubelet certificates, consider using kubelet-insecure-tls instead.")
@@ -174,7 +174,7 @@ func (o MetricsServerOptions) Run(stopCh <-chan struct{}) error {
 	kubeletConfig := summary.GetKubeletConfig(clientConfig, o.KubeletPort, o.InsecureKubeletTLS, o.DeprecatedCompletelyInsecureKubelet)
 	kubeletClient, err := summary.KubeletClientFor(kubeletConfig)
 	if err != nil {
-		return fmt.Errorf("unable to construct a client to connect to the kubelets: %v", err)
+		return fmt.Errorf("unable to construct a client to connect to the kubelet: %v", err)
 	}
 
 	// set up an address resolver according to the user's priorities

--- a/pkg/sources/summary/configs.go
+++ b/pkg/sources/summary/configs.go
@@ -40,7 +40,7 @@ func GetKubeletConfig(baseKubeConfig *rest.Config, port int, insecureTLS bool, c
 	return kubeletConfig
 }
 
-// KubeletClientConfig represents configuration for connecting to Kubelets.
+// KubeletClientConfig represents configuration for connecting to the Kubelet.
 type KubeletClientConfig struct {
 	Port                         int
 	RESTConfig                   *rest.Config


### PR DESCRIPTION
Fix typo: kubelets -> kubelet