### PR TITLE
Remove unneeded RBAC rules

### DIFF
--- a/deploy/1.8+/resource-reader.yaml
+++ b/deploy/1.8+/resource-reader.yaml
@@ -10,15 +10,6 @@ rules:
   - pods
   - nodes
   - nodes/stats
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - "extensions"
-  resources:
-  - deployments
   verbs:
   - get
   - list


### PR DESCRIPTION
`namespaces` and `deployments` are not needed as permissions.