### PR TITLE
fix: do not skip unready nodes

### DIFF
--- a/pkg/sources/summary/summary.go
+++ b/pkg/sources/summary/summary.go
@@ -274,18 +274,6 @@ func (p *summaryProvider) GetMetricSources() ([]sources.MetricSource, error) {
 }
 
 func (p *summaryProvider) getNodeInfo(node *corev1.Node) (NodeInfo, error) {
-	// TODO(directxman12): why do we skip unready nodes?
-	nodeReady := false
-	for _, c := range node.Status.Conditions {
-		if c.Type == corev1.NodeReady {
-			nodeReady = c.Status == corev1.ConditionTrue
-			break
-		}
-	}
-	if !nodeReady {
-		return NodeInfo{}, fmt.Errorf("node %v is not ready", node.Name)
-	}
-
 	addr, err := p.addrResolver.NodeAddress(node)
 	if err != nil {
 		return NodeInfo{}, err


### PR DESCRIPTION
When node in notready state, kubelet may still able to return metrics (e.g. node in MemoryPressure, CpuPressures or CNI not ready, the node status is not ready, but kubelet can work). We should not just skip metrics for node in these status.