### PR TITLE
run metrics server as non privileged user and in non rootfs

### DIFF
--- a/deploy/1.8+/metrics-server-deployment.yaml
+++ b/deploy/1.8+/metrics-server-deployment.yaml
@@ -30,6 +30,16 @@ spec:
       containers:
       - name: metrics-server
         image: k8s.gcr.io/metrics-server-amd64:v0.3.6
+        args:
+          - --cert-dir=/tmp
+          - --secure-port=4443
+        ports:
+        - name: main-port
+          containerPort: 4443
+          protocol: TCP
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
         imagePullPolicy: Always
         volumeMounts:
         - name: tmp-dir

--- a/deploy/1.8+/metrics-server-service.yaml
+++ b/deploy/1.8+/metrics-server-service.yaml
@@ -13,4 +13,4 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: main-port

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -2,4 +2,6 @@ FROM BASEIMAGE
 
 COPY metrics-server /
 
+USER 65534
+
 ENTRYPOINT ["/metrics-server"]


### PR DESCRIPTION
The PR adds support for running metrics server as non root user and uses `/tmp` dir for storing certs.

Related issue: https://github.com/kubernetes-incubator/metrics-server/issues/152

cc/ @DirectXMan12 