### PR TITLE
Adds option to enable connecting to Kubelets via the API server proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ behavior:
   recommended for production usage, but can be useful in test clusters
   with self-signed Kubelet serving certificates.
 
-- `--kubelet-port`: the port to use to connect to the Kubelet or API server
-  proxy if enabled (defaults to the default secure Kubelet port, 10250).
+- `--kubelet-port`: the port to use to connect to the Kubelet (defaults to the
+  default secure Kubelet port, 10250).
 
 - `--kubelet-preferred-address-types`: the order in which to consider
   different Kubelet node address types when connecting to Kubelet.

--- a/README.md
+++ b/README.md
@@ -72,9 +72,11 @@ behavior:
   recommended for production usage, but can be useful in test clusters
   with self-signed Kubelet serving certificates.
 
-- `--kubelet-port`: the port to use to connect to the Kubelet (defaults to
-  the default secure Kubelet port, 10250).
+- `--kubelet-port`: the port to use to connect to the Kubelet or API server
+  proxy if enabled (defaults to the default secure Kubelet port, 10250).
 
 - `--kubelet-preferred-address-types`: the order in which to consider
   different Kubelet node address types when connecting to Kubelet.
   Functions similarly to the flag of the same name on the API server.
+
+- `--use-apiserver-proxy`: connect to Kubelets via the API server proxy.

--- a/cmd/metrics-server/app/start.go
+++ b/cmd/metrics-server/app/start.go
@@ -59,7 +59,7 @@ func NewCommandStartMetricsServer(out, errOut io.Writer, stopCh <-chan struct{})
 	flags.BoolVar(&o.InsecureKubeletTLS, "kubelet-insecure-tls", o.InsecureKubeletTLS, "Do not verify CA of serving certificates presented by Kubelets.  For testing purposes only.")
 	flags.BoolVar(&o.DeprecatedCompletelyInsecureKubelet, "deprecated-kubelet-completely-insecure", o.DeprecatedCompletelyInsecureKubelet, "Do not use any encryption, authorization, or authentication when communicating with the Kubelet.")
 	flags.BoolVar(&o.UseAPIServerProxy, "use-apiserver-proxy", o.UseAPIServerProxy, "Use the API server proxy to connect to Kubelets.")
-	flags.IntVar(&o.KubeletPort, "kubelet-port", o.KubeletPort, "The port to use to connect to Kubelets or API server when using it's proxy.")
+	flags.IntVar(&o.KubeletPort, "kubelet-port", o.KubeletPort, "The port to use to connect to Kubelets.")
 	flags.StringVar(&o.Kubeconfig, "kubeconfig", o.Kubeconfig, "The path to the kubeconfig used to connect to the Kubernetes API server and the Kubelets (defaults to in-cluster config)")
 	flags.StringSliceVar(&o.KubeletPreferredAddressTypes, "kubelet-preferred-address-types", o.KubeletPreferredAddressTypes, "The priority of node address types to use when determining which address to use to connect to a particular node")
 

--- a/cmd/metrics-server/app/start.go
+++ b/cmd/metrics-server/app/start.go
@@ -58,7 +58,8 @@ func NewCommandStartMetricsServer(out, errOut io.Writer, stopCh <-chan struct{})
 
 	flags.BoolVar(&o.InsecureKubeletTLS, "kubelet-insecure-tls", o.InsecureKubeletTLS, "Do not verify CA of serving certificates presented by Kubelets.  For testing purposes only.")
 	flags.BoolVar(&o.DeprecatedCompletelyInsecureKubelet, "deprecated-kubelet-completely-insecure", o.DeprecatedCompletelyInsecureKubelet, "Do not use any encryption, authorization, or authentication when communicating with the Kubelet.")
-	flags.IntVar(&o.KubeletPort, "kubelet-port", o.KubeletPort, "The port to use to connect to Kubelets.")
+	flags.BoolVar(&o.UseAPIServerProxy, "use-apiserver-proxy", o.UseAPIServerProxy, "Use the API server proxy to connect to Kubelets.")
+	flags.IntVar(&o.KubeletPort, "kubelet-port", o.KubeletPort, "The port to use to connect to Kubelets or API server when using it's proxy.")
 	flags.StringVar(&o.Kubeconfig, "kubeconfig", o.Kubeconfig, "The path to the kubeconfig used to connect to the Kubernetes API server and the Kubelets (defaults to in-cluster config)")
 	flags.StringSliceVar(&o.KubeletPreferredAddressTypes, "kubelet-preferred-address-types", o.KubeletPreferredAddressTypes, "The priority of node address types to use when determining which address to use to connect to a particular node")
 
@@ -88,6 +89,7 @@ type MetricsServerOptions struct {
 
 	KubeletPort                  int
 	InsecureKubeletTLS           bool
+	UseAPIServerProxy            bool
 	KubeletPreferredAddressTypes []string
 
 	DeprecatedCompletelyInsecureKubelet bool
@@ -171,7 +173,8 @@ func (o MetricsServerOptions) Run(stopCh <-chan struct{}) error {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 
 	// set up the source manager
-	kubeletConfig := summary.GetKubeletConfig(clientConfig, o.KubeletPort, o.InsecureKubeletTLS, o.DeprecatedCompletelyInsecureKubelet)
+	kubeletConfig := summary.GetKubeletConfig(clientConfig, o.KubeletPort, o.InsecureKubeletTLS,
+		o.DeprecatedCompletelyInsecureKubelet, o.UseAPIServerProxy)
 	kubeletClient, err := summary.KubeletClientFor(kubeletConfig)
 	if err != nil {
 		return fmt.Errorf("unable to construct a client to connect to the kubelets: %v", err)

--- a/pkg/sources/summary/configs.go
+++ b/pkg/sources/summary/configs.go
@@ -21,7 +21,7 @@ import (
 )
 
 // GetKubeletConfig fetches connection config for connecting to the Kubelet.
-func GetKubeletConfig(baseKubeConfig *rest.Config, port int, insecureTLS bool, completelyInsecure bool) *KubeletClientConfig {
+func GetKubeletConfig(baseKubeConfig *rest.Config, port int, insecureTLS bool, completelyInsecure bool, apiserverProxy bool) *KubeletClientConfig {
 	cfg := rest.CopyConfig(baseKubeConfig)
 	if completelyInsecure {
 		cfg = rest.AnonymousClientConfig(cfg)        // don't use auth to avoid leaking auth details to insecure endpoints
@@ -35,6 +35,7 @@ func GetKubeletConfig(baseKubeConfig *rest.Config, port int, insecureTLS bool, c
 		Port:                         port,
 		RESTConfig:                   cfg,
 		DeprecatedCompletelyInsecure: completelyInsecure,
+		UseAPIServerProxy:            apiserverProxy,
 	}
 
 	return kubeletConfig
@@ -45,6 +46,7 @@ type KubeletClientConfig struct {
 	Port                         int
 	RESTConfig                   *rest.Config
 	DeprecatedCompletelyInsecure bool
+	UseAPIServerProxy            bool
 }
 
 // KubeletClientFor constructs a new KubeletInterface for the given configuration.
@@ -54,5 +56,5 @@ func KubeletClientFor(config *KubeletClientConfig) (KubeletInterface, error) {
 		return nil, fmt.Errorf("unable to construct transport: %v", err)
 	}
 
-	return NewKubeletClient(transport, config.Port, config.DeprecatedCompletelyInsecure)
+	return NewKubeletClient(transport, config.Port, config.DeprecatedCompletelyInsecure, config.UseAPIServerProxy)
 }

--- a/pkg/sources/summary/configs.go
+++ b/pkg/sources/summary/configs.go
@@ -31,6 +31,7 @@ func GetKubeletConfig(baseKubeConfig *rest.Config, port int, insecureTLS bool, c
 		cfg.TLSClientConfig.CAData = nil
 		cfg.TLSClientConfig.CAFile = ""
 	}
+
 	kubeletConfig := &KubeletClientConfig{
 		Port:                         port,
 		RESTConfig:                   cfg,
@@ -56,5 +57,5 @@ func KubeletClientFor(config *KubeletClientConfig) (KubeletInterface, error) {
 		return nil, fmt.Errorf("unable to construct transport: %v", err)
 	}
 
-	return NewKubeletClient(transport, config.Port, config.DeprecatedCompletelyInsecure, config.UseAPIServerProxy)
+	return NewKubeletClient(transport, config)
 }


### PR DESCRIPTION
Signed-off-by: Joshua Van Leeuwen <joshua.vanleeuwen@jetstack.io>

/kind feature

Fixes #205 

```release-note
Adds CLI flag to enable metrics-server to connect to Kubelets via the API server proxy 
```