### PR TITLE
Use internal IP for node address resolution

### DIFF
--- a/deploy/1.8+/metrics-server-deployment.yaml
+++ b/deploy/1.8+/metrics-server-deployment.yaml
@@ -31,6 +31,9 @@ spec:
       - name: metrics-server
         image: k8s.gcr.io/metrics-server-amd64:v0.3.1
         imagePullPolicy: Always
+        command:
+        - /metrics-server
+        - --kubelet-preferred-address-types=InternalIP
         volumeMounts:
         - name: tmp-dir
           mountPath: /tmp


### PR DESCRIPTION
When I deployed the metrics-server with the default deployment yaml files, I got the following errors.

```
E0313 00:12:38.510345       1 manager.go:102] unable to fully collect metrics: [unable to fully scrape metrics from source kubelet_summary:ip-10-209-2-54.ec2.internal: unable to fetch metrics from Kubelet ip-10-209-2-54.ec2.internal (ip-10-209-2-54): Get https://ip-10-209-2-54:10250/stats/summary/: dial tcp: lookup ip-10-209-2-54 on 172.20.0.10:53: no such host, unable to fully scrape metrics from source kubelet_summary:ip-10-209-1-54.ec2.internal: unable to fetch metrics from Kubelet ip-10-209-1-54.ec2.internal (ip-10-209-1-54): Get https://ip-10-209-1-54:10250/stats/summary/: dial tcp: lookup ip-10-209-1-54 on 172.20.0.10:53: no such host]
```

The ip address `172.20.0.10:53` does not seem right. It should be resolving using the IP address of the nodes.