### PR TITLE
add kubernetes.io/cluster-service label

### DIFF
--- a/deploy/1.8+/metrics-server-service.yaml
+++ b/deploy/1.8+/metrics-server-service.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     kubernetes.io/name: "Metrics-server"
+    kubernetes.io/cluster-service: "true"
 spec:
   selector:
     k8s-app: metrics-server


### PR DESCRIPTION
This label is needed for `kube-system` services to be listed by `kubectl
cluster-info`. Eg.,

    $ kubectl cluster-info
    Kubernetes master is running at https://<foo>.eks.amazonaws.com
    CoreDNS is running at https://<foo>.eks.amazonaws.com/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
    Metrics-server is running at https://<foo>.eks.amazonaws.com/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy