### PR TITLE
Update README.md: fix official doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## User guide
 
 You can find the user guide in
-[the official Kubernetes documentation](https://kubernetes.io/docs/tasks/debug-application-cluster/core-metrics-pipeline/).
+[the official Kubernetes documentation](https://kubernetes.io/docs/tasks/debug-application-cluster/resource-metrics-pipeline/).
 
 ## Design
 


### PR DESCRIPTION
The official documentation link was broken and this commit fixes it.