### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## User guide
 
 You can find the user guide in
-[the official Kubernetes documentation](https://kubernetes.io/docs/tasks/debug-application-cluster/core-metrics-pipeline/).
+[the official Kubernetes documentation](https://kubernetes.io/docs/tasks/debug-application-cluster/resource-metrics-pipeline/).
 
 ## Design
 


### PR DESCRIPTION
I noticed the link to the docs site from the README is broken. This PR updates the link to what I believe it should be pointing to.