### PR TITLE
Fix typo in OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,4 +8,3 @@ approvers:
 reviewers:
 - metrics-server-approvers
 - metrics-server-reviewers
-- 


### PR DESCRIPTION
I'm doing some org/repo-wide OWNERS file parsing, and ran across this invalid OWNERS file.  Our `verify-owners` plugin should pick up these kinds of errors in the future