### PR TITLE
Give metric-server permission to read namespaces

### DIFF
--- a/deploy/1.8+/resource-reader.yaml
+++ b/deploy/1.8+/resource-reader.yaml
@@ -10,6 +10,7 @@ rules:
   - pods
   - nodes
   - nodes/stats
+  - namespaces
   verbs:
   - get
   - list


### PR DESCRIPTION
I was getting the following error in minikube k8s 1.15 cluster.

`E0704 08:10:54.668325       1 reflector.go:205] github.com/kubernetes-incubator/metrics-server/metrics/processors/namespace_based_enricher.go:85: Failed to list *v1.Namespace: namespaces is forbidden: User "system:serviceaccount:kube-system:metrics-server" cannot list resource "namespaces" in API group "" at the cluster scope`

I tested the fix using the following command:

```
minikube delete; minikube start --extra-config=kubelet.authentication-token-webhook=true

kubectl apply -f deploy/1.8+/
```
