### PR TITLE
Allow accessing node metrics

### DIFF
--- a/deploy/1.8+/aggregated-metrics-reader.yaml
+++ b/deploy/1.8+/aggregated-metrics-reader.yaml
@@ -8,5 +8,5 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
 - apiGroups: ["metrics.k8s.io"]
-  resources: ["pods"]
+  resources: ["pods", "nodes"]
   verbs: ["get", "list", "watch"]


### PR DESCRIPTION
Before:
```
$ kubectl top nodes
Error from server (Forbidden): nodes.metrics.k8s.io is forbidden: User "127.0.0.1" cannot list nodes.metrics.k8s.io at the cluster scope.
```

After:
```
$ kubectl top nodes
NAME            CPU(cores)   CPU%   MEMORY(bytes)   MEMORY%
ubuntu-bionic   75m          3%     2598Mi          67%
```