### PR TITLE
Revert " Do not run as root by default in Docker"

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -2,8 +2,4 @@ FROM BASEIMAGE
 
 COPY metrics-server /
 
-RUN adduser -D metrics-server
-
-USER metrics-server
-
 ENTRYPOINT ["/metrics-server"]


### PR DESCRIPTION
Reverts kubernetes-incubator/metrics-server#260

This doesn't work and prevents building Metrics Server image.

/cc @serathius @yuwenma @reetasingh @kawych 

fixes #294 