### PR TITLE
Upgrade the apiVersion to apps/v1 for deployment

### DIFF
--- a/deploy/1.8+/metrics-server-deployment.yaml
+++ b/deploy/1.8+/metrics-server-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: metrics-server
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metrics-server


### PR DESCRIPTION
`apiVersion: extensions/v1beta1` for deployments will not be supported anymore in 1.16.

From: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.15.md
> DaemonSet, Deployment, and ReplicaSet resources will no longer be served from extensions/v1beta1, apps/v1beta1, or apps/v1beta2 in v1.16. Migrate to the apps/v1 API, available since v1.9. Existing persisted data can be retrieved via the apps/v1 API.

As this has been available since 1.9 I'm wondering if I need to create a new folder for this or is it fine keeping it in 1.8+ as I don't think a lot of people are still running k8s < 1.9?

Thanks
Joseph