### PR TITLE
Update to stable "rbac.authorization.k8s.io/v1"

### DIFF
--- a/deploy/1.8+/aggregated-metrics-reader.yaml
+++ b/deploy/1.8+/aggregated-metrics-reader.yaml
@@ -1,5 +1,6 @@
-kind: ClusterRole
+---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
   name: system:aggregated-metrics-reader
   labels:

--- a/deploy/1.8+/auth-delegator.yaml
+++ b/deploy/1.8+/auth-delegator.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: metrics-server:system:auth-delegator

--- a/deploy/1.8+/auth-reader.yaml
+++ b/deploy/1.8+/auth-reader.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-server-auth-reader


### PR DESCRIPTION
`rbac.authorization.k8s.io/v1beta1` API is promoted to `rbac.authorization.k8s.io/v1` in v1.8.
Ref https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.8.md